### PR TITLE
Lock queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ results
 *.pyc
 *#*
 nohup.out
-*.swp
+*.sw[a-z]
 tags

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,7 +62,6 @@ build/db:$(START_OBJECTS) $(OBJECTS)
 
 build/tests:$(OBJECTS) $(BATCHING_OBJECTS) $(TESTOBJECTS) $(NON_MAIN_STARTS)
 	@$(CXX) $(CFLAGS) $(INCLUDE) -o $@ $^ $(LIBS) $(TEST_LIBS)
-	build/tests
 
 $(DEPSDIR)/stamp:
 	@mkdir -p $(DEPSDIR)

--- a/include/batch/MS_queue.h
+++ b/include/batch/MS_queue.h
@@ -1,0 +1,60 @@
+#ifndef _MS_QUEUE_H_
+#define _MS_QUEUE_H_
+
+// TODO:
+//    - Memory Management. Right now we have memory leakage within the destructor
+//    since the lock stages are never deallocated!
+//    - Overloading of new/delete.
+
+/*
+ *    MS Queue
+ *
+ *    A latch-free, one-consumer, one-producer queue of LockStages. Resembles
+ *    SimpleQueue, but does not reserve memory up-front.
+ *
+ *    Since this is the queue that is present within the lock table of 
+ *    global schedule, we only ever pop head and merge a batch queue in.
+ *
+ *    The queue implementation is a modified MS-queue implementation that is
+ *    lock-free and non-blocking. See https://www.research.ibm.com/people/m/michael/podc-1996.pdf.
+ */
+
+template <typename Elt>
+class MSQueue {
+public:
+  MSQueue();
+
+  // Queue Element class definition
+  class QueueElt {
+  public:
+    QueueElt();
+    QueueElt(Elt* e);
+    Elt* contents;
+    QueueElt* next;
+    
+    Elt* get_contents();
+    QueueElt* get_next_elt();
+    bool set_next_elt(QueueElt* ne);
+  };
+
+  QueueElt* head;
+  QueueElt* tail; 
+  
+  // user interface
+  bool is_empty() const;
+  
+  QueueElt* peek_tail_elt() const;
+  QueueElt* peek_head_elt() const;
+  Elt* peek_tail() const;
+  Elt* peek_head() const; 
+  
+  Elt* try_pop_head();
+  
+  // The implicit assumption is that lq is immutable at the time of
+  // merging. 
+  void merge_queue(MSQueue<Elt>* lq);
+};
+
+#include "batch/MS_queue_impl.h"
+
+#endif // _MS_QUEUE_H_

--- a/include/batch/MS_queue_impl.h
+++ b/include/batch/MS_queue_impl.h
@@ -1,0 +1,130 @@
+#include "batch/MS_queue.h"
+#include "util.h"
+
+#include <cassert>
+
+// Definitions of QueueElt functions.
+template <typename Elt>
+MSQueue<Elt>::QueueElt::QueueElt() :
+  contents(nullptr),
+  next(nullptr)
+{};
+
+template <typename Elt>
+MSQueue<Elt>::QueueElt::QueueElt(Elt* e):
+  contents(e),
+  next(nullptr)
+{};
+
+template <typename Elt>
+Elt* MSQueue<Elt>::QueueElt::get_contents() {
+  return contents;
+};
+
+template <typename Elt>
+typename MSQueue<Elt>::QueueElt* MSQueue<Elt>::QueueElt::get_next_elt() {
+  return next;
+};
+
+template <typename Elt>
+bool MSQueue<Elt>::QueueElt::set_next_elt(MSQueue<Elt>::QueueElt* ne) {
+  return cmp_and_swap((uint64_t*) &next, 0, (uint64_t) ne); 
+};
+
+template <typename Elt>
+// Definitions of the MSQueue functions.
+MSQueue<Elt>::MSQueue() {
+  QueueElt* dummy_node = new QueueElt();
+  head = dummy_node;
+  tail = dummy_node;
+}
+
+template <typename Elt>
+bool MSQueue<Elt>::is_empty() const {
+  return (head == tail);
+}
+
+template <typename Elt>
+typename MSQueue<Elt>::QueueElt* MSQueue<Elt>::peek_head_elt() const {
+  return head->get_next_elt();
+}
+
+template <typename Elt>
+Elt* MSQueue<Elt>::peek_head() const {
+  QueueElt* actual_head = peek_head_elt();
+  if (actual_head != nullptr) return actual_head->get_contents();
+
+  return nullptr;
+}
+
+template <typename Elt>
+typename MSQueue<Elt>::QueueElt* MSQueue<Elt>::peek_tail_elt() const {
+  if (is_empty()) return nullptr;
+
+  return tail;
+}
+
+template <typename Elt>
+Elt* MSQueue<Elt>::peek_tail() const {
+  QueueElt* tail = peek_tail_elt();
+  if (tail != nullptr) return tail->get_contents();
+
+  return nullptr;
+}
+
+template <typename Elt>
+Elt* MSQueue<Elt>::try_pop_head() {
+  QueueElt* m_head;
+  QueueElt* m_tail;
+  QueueElt* m_next;
+  while(true) {
+    m_head = head;
+    m_tail = tail;
+    m_next = m_head->get_next_elt();
+    barrier();
+    if (head == m_head) {               // head didn't change
+      if (m_head == m_tail) {           // empty or tail behind
+        if (m_next == nullptr) {
+          return nullptr;               // empty
+        } 
+        
+        continue;
+      }
+
+      // not empty and the tail is not lagging behind
+      if (cmp_and_swap(
+            (uint64_t*) &head,
+            (uint64_t) m_head,
+            (uint64_t) m_next)) break;
+    }
+  }  
+
+  return m_next->get_contents();
+}
+
+template <typename Elt>
+void MSQueue<Elt>::merge_queue(MSQueue<Elt>* lq) {
+  if (lq->is_empty()) return;
+
+  QueueElt* m_tail = tail;
+  QueueElt* lq_head = lq->peek_head_elt();
+  QueueElt* lq_tail = lq->peek_tail_elt();
+  barrier();
+
+  // single produced and single consumer model in this modified queue
+  // means that only merge may move tail and so it is free to only 
+  // CAS once.
+  bool CAS_success = false;
+  assert(lq_tail->get_next_elt() == nullptr);
+  assert(m_tail->get_next_elt() == nullptr);
+  // set the next stage
+  CAS_success = m_tail->set_next_elt(lq_head);
+  assert(CAS_success);
+
+  // swing the tail around.
+  CAS_success= cmp_and_swap(
+     (uint64_t*) &tail, 
+     (uint64_t) m_tail,
+     (uint64_t) lq_tail);
+  assert(CAS_success); 
+}

--- a/include/batch/lock_queue.h
+++ b/include/batch/lock_queue.h
@@ -1,0 +1,36 @@
+#ifndef _LOCK_QUEUE_H_
+#define _LOCK_QUEUE_H_
+
+#include "batch/lock_stage.h"
+#include "batch/MS_queue.h"
+
+class BatchLockQueue;
+
+// TODO:
+//    - Memory Management. Right now we have memory leakage within the destructor
+//    since the lock stages are never deallocated!
+//    - Overloading of new/delete.
+
+/*
+ * LockQueue
+ *    
+ *    A queue of lock stages implemented as a MS-queue. See batch/MS_queue.h for details. 
+ */
+typedef MSQueue<LockStage> LockQueue;
+
+/*
+ * BatchLockQueue
+ *
+ *    Basically a LockQueue with the added functionality of non-thread safe
+ *    addition of lock stages. Used only by the scheduling threads before
+ *    merging into the global schedule.
+ */
+class BatchLockQueue : public MSQueue<LockStage> {
+public:
+  // TODO:
+  //    This creates an element using the new directive. Make sure to override
+  //    it and return memory whenever necessary.
+  void non_concurrent_push_tail(LockStage* ls);
+};
+
+#endif // _LOCK_QUEUE_H_

--- a/include/batch/lock_stage.h
+++ b/include/batch/lock_stage.h
@@ -31,7 +31,6 @@ public:
 protected:
   // The number of transactions holding on to the lock.
   uint64_t holders;
-  LockStage* next_stage;
   LockType l_type;
   RequestingActions requesters;
 
@@ -39,8 +38,7 @@ public:
   LockStage();
   LockStage(
       RequestingActions requesters,
-      LockType lt,
-      LockStage* ns = nullptr);
+      LockType lt);
 
   // Returns true if successful and false otherwise
   //
@@ -49,12 +47,7 @@ public:
   bool add_to_stage(Action_spt txn, LockType lt);
   // Returns the new value of holders
   uint64_t decrement_holders(); 
-  // Returns true if successful and false otherwise.
-  //
-  // Failure reported when next_stage was non-null
-  bool set_next_stage(LockStage* ns);
   
-  LockStage* get_next_stage();
   const RequestingActions& get_requesters() const; 
   uint64_t get_holders() const;
 

--- a/include/test/test_MS_queue.h
+++ b/include/test/test_MS_queue.h
@@ -1,0 +1,15 @@
+#ifndef _TEST_MS_QUEUE_H_
+#define _TEST_MS_QUEUE_H_
+
+#include "batch/MS_queue.h"
+
+template <typename Elt>
+class TestMSQueue : public MSQueue<Elt> {
+  public:
+    void non_concurrent_push_tail(Elt* e) {
+      this->tail->set_next_elt(new typename MSQueue<Elt>::QueueElt(e));
+      this->tail = this->tail->get_next_elt();
+    }
+};
+
+#endif

--- a/include/test/test_lock_stage.h
+++ b/include/test/test_lock_stage.h
@@ -1,11 +1,7 @@
 #ifndef _TEST_LOCK_STAGE_H_
 #define _TEST_LOCK_STAGE_H_
 
-bool operator==(const LockStage& ls1, const LockStage& ls2) {
-  return (ls1.requesters == ls2.requesters &&
-    ls1.holders == ls2.holders &&
-    ls1.l_type == ls2.l_type);
-}
+#include "batch/lock_stage.h"
 
 /*
  * Simple Lock Stage Test fixture.
@@ -15,6 +11,7 @@ bool operator==(const LockStage& ls1, const LockStage& ls2) {
  */
 class TestLockStage : public LockStage {
 public:
+  TestLockStage(): LockStage() {};
   TestLockStage(LockStage& ls): LockStage(ls) {};
 
   uint64_t get_holders() const {return holders;}

--- a/src/batch/lock_queue.cc
+++ b/src/batch/lock_queue.cc
@@ -1,0 +1,7 @@
+#include "batch/lock_queue.h"
+#include "util.h"
+
+void BatchLockQueue::non_concurrent_push_tail(LockStage* ls) {
+  this->tail->set_next_elt(new typename MSQueue<LockStage>::QueueElt(ls));
+  this->tail = this->tail->get_next_elt();
+}

--- a/src/batch/lock_stage.cc
+++ b/src/batch/lock_stage.cc
@@ -4,17 +4,14 @@
 
 LockStage::LockStage(): 
     holders(0),
-    next_stage(nullptr),
     l_type(LockType::shared),
     requesters({})
   {};
 
 LockStage::LockStage(
       RequestingActions requesters,
-      LockType lt,
-      LockStage* ns):
+      LockType lt):
     holders(requesters.size()),
-    next_stage(ns),
     l_type(lt),
     requesters(requesters)
   {
@@ -37,14 +34,6 @@ bool LockStage::add_to_stage(Action_spt txn, LockType lt) {
 
 uint64_t LockStage::decrement_holders() {
   return fetch_and_decrement(&holders);
-}
-
-bool LockStage::set_next_stage(LockStage* ns) {
-  return cmp_and_swap((uint64_t*) &next_stage, 0, (uint64_t) ns); 
-}
-
-LockStage* LockStage::get_next_stage() {
-  return next_stage; 
 }
 
 const LockStage::RequestingActions& LockStage::get_requesters() const {

--- a/test/MS_queue_test.cc
+++ b/test/MS_queue_test.cc
@@ -1,0 +1,143 @@
+#include "gtest/gtest.h"
+
+#include "test/test_MS_queue.h"
+
+#include <vector>
+#include <thread>
+
+// NOTE:
+//    All of the tests of MSQueues are done using integers for simplicity.
+
+class MSQueueTest : public testing::Test {
+protected:
+  std::shared_ptr<TestMSQueue<int>> make_test_queue(int n, int start_elt = 0) {
+    std::shared_ptr<TestMSQueue<int>> tmq = std::make_shared<TestMSQueue<int>>();
+    for (int i = start_elt; i < start_elt + n; i++) tmq->non_concurrent_push_tail(new int(i));
+
+    return tmq;
+  }
+
+  std::shared_ptr<MSQueue<int>> make_queue(int n, int start_elt = 0) {
+    auto tmq = make_test_queue(n, start_elt);
+
+    std::shared_ptr<MSQueue<int>> lq = std::make_shared<MSQueue<int>>();
+    lq->merge_queue(tmq.get());
+    return lq;
+  }
+};
+
+TEST_F(MSQueueTest, constructorTest) {
+  MSQueue<int> lq;
+  ASSERT_TRUE(lq.is_empty());
+} 
+
+TEST_F(MSQueueTest, TestFixture_non_concurrent_push_tailTest) {
+  TestMSQueue<int> tmq;
+  std::vector<int*> elts;
+  for (int i = 0; i < 100; i ++) {
+    elts.push_back(new int(i));
+    tmq.non_concurrent_push_tail(elts[i]);
+
+    // the tail moves while the head remains.
+    ASSERT_EQ(elts[i], tmq.peek_tail());
+    ASSERT_EQ(elts[0], tmq.peek_head());
+  }
+
+  // The queue is well formed.
+  auto curr = tmq.peek_head_elt();
+  for (int i = 0; i < 100; i++) {
+    if (i != 99) ASSERT_EQ(curr->get_next_elt()->get_contents(), elts[i+1]);
+
+    curr = curr->get_next_elt();
+  }
+
+  ASSERT_EQ(nullptr, tmq.peek_tail_elt()->get_next_elt());
+}
+
+TEST_F(MSQueueTest, merge_queueNonconcurrentTest) {
+  auto tmq = make_test_queue(100);
+  std::shared_ptr<MSQueue<int>> msQueue = std::make_shared<MSQueue<int>>();
+
+  auto checkQueue = [](auto head_elt, int elts){
+    auto* curr = head_elt;
+    for (unsigned int i = 0; i < elts; i++) {
+      if (i != elts-1) ASSERT_EQ(i, *(curr->get_contents()));
+
+      curr = curr->get_next_elt();
+    }
+  };
+
+  msQueue->merge_queue(tmq.get());
+
+  // should contain all of the elts there 
+  ASSERT_EQ(*msQueue->peek_head(), 0);
+  ASSERT_EQ(*msQueue->peek_tail(), 99);
+  checkQueue(msQueue->peek_head_elt(), 100);
+
+  // repeated merging should leave the former elements unchanged and add more elements.
+  tmq = make_test_queue(100, 100);
+  msQueue->merge_queue(tmq.get());
+  
+  ASSERT_EQ(*msQueue->peek_head(), 0);
+  ASSERT_EQ(*msQueue->peek_tail(), 199);
+  checkQueue(msQueue->peek_head_elt(), 200);
+}
+
+TEST_F(MSQueueTest, try_pop_headNonconcurrentTest) {
+  auto msQueue = make_queue(2);
+
+  auto head = msQueue->peek_head_elt();
+  auto tail = msQueue->peek_tail_elt();
+  auto next_head = head->get_next_elt();
+
+  ASSERT_EQ(0, *msQueue->try_pop_head());
+  ASSERT_EQ(next_head, msQueue->peek_head_elt());
+  ASSERT_EQ(tail, msQueue->peek_tail_elt());
+
+  ASSERT_EQ(1, *msQueue->try_pop_head());
+  ASSERT_EQ(nullptr, msQueue->peek_head_elt());
+  ASSERT_EQ(nullptr, msQueue->peek_head());
+  ASSERT_EQ(nullptr, msQueue->peek_tail_elt());
+  ASSERT_EQ(nullptr, msQueue->peek_tail());
+}
+
+TEST_F(MSQueueTest, concurrentPopMergeTest) {
+  unsigned int elts_count = 100;
+  std::thread threads[2];
+
+  for (unsigned int k = 0; k < 100; k++) {
+    std::vector<std::shared_ptr<int>> elts(elts_count);
+    MSQueue<int> msQueue;
+
+    // create the producer
+    threads[0] = std::thread([this, &msQueue, &elts, elts_count](){
+      for (unsigned int i = 0; i < elts_count; i++) {
+        TestMSQueue<int> tmq; 
+        elts[i] = std::make_shared<int>(i);
+        tmq.non_concurrent_push_tail(elts[i].get()); 
+
+        msQueue.merge_queue(&tmq);
+     }
+    }); 
+
+    threads[1] = std::thread([this, &msQueue, &elts, elts_count](){
+      int* currDeqInt;
+      for (unsigned int i = 0; i < elts_count; i++) {
+        // make sure we dequeu
+        while((currDeqInt = msQueue.try_pop_head()) == nullptr) ;
+
+        // consistent values from dequeueing
+        ASSERT_EQ(elts[i].get(), currDeqInt);
+      }
+    });
+
+    threads[0].join();
+    threads[1].join();
+ 
+    // the queue should be empty by now
+    ASSERT_EQ(nullptr, msQueue.peek_head_elt());
+    ASSERT_EQ(nullptr, msQueue.peek_head());
+    ASSERT_EQ(nullptr, msQueue.peek_tail_elt());
+    ASSERT_EQ(nullptr, msQueue.peek_tail());
+  }
+}

--- a/test/lock_queue_test.cc
+++ b/test/lock_queue_test.cc
@@ -1,0 +1,38 @@
+#include "gtest/gtest.h"
+#include "batch/lock_queue.h"
+#include "test/test_lock_stage.h"
+#include "util.h"
+
+class LockQueueTest : public testing::Test {
+protected:
+  std::vector<std::shared_ptr<TestLockStage>> get_test_lock_stages(unsigned int num) {
+    std::vector<std::shared_ptr<TestLockStage>> tlss; 
+    for (unsigned int i = 0; i < num; i++) {
+      tlss.push_back(std::make_shared<TestLockStage>());
+    }
+
+    return tlss;
+  }
+};
+
+TEST_F(LockQueueTest, BatchLockQueue_non_concurrent_push_tailTest) {
+  BatchLockQueue blq;
+  auto testLockStages = get_test_lock_stages(100);
+  for (unsigned int i = 0; i < 100; i ++) {
+    blq.non_concurrent_push_tail(testLockStages[i].get());
+
+    // the tail moves while the head remains.
+    ASSERT_EQ(blq.peek_tail(), testLockStages[i].get());
+    ASSERT_EQ(blq.peek_head(), testLockStages[0].get());
+  }
+
+  // the queue is well formed
+  BatchLockQueue::QueueElt* curr = blq.peek_head_elt();
+  for (unsigned int i = 0; i < 100; i++) {
+    if (i != 99) ASSERT_EQ(testLockStages[i].get(), curr->get_contents());
+
+    curr = curr->get_next_elt();
+  }
+
+  ASSERT_EQ(nullptr, blq.peek_tail_elt()->get_next_elt());
+} 


### PR DESCRIPTION
Lock queue with tests. Lock queue now is a much thinner class than before. Most of lock passing (if any -- we still have to think about that in the context of execution threads) will be done in a higher-up class. This makes more sense and is more OOP.

The concurrent test passes so it should hopefully be ok. That said, there is no way of enforcing parallel scenarios so...