### PR TITLE
Batch action

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 CFLAGS=-O2 -g -Wall -Wextra -Werror -std=c++14 -Wno-sign-compare 
 CFLAGS+=-DSNAPSHOT_ISOLATION=0 -DSMALL_RECORDS=0 -DREAD_COMMITTED=1
-LIBS=-lnuma -lpthread -lrt -lcityhash 
+LIBS=-lnuma -lpthread -lrt -lcityhash
 TEST_LIBS=-lgtest
 CXX=g++
 
@@ -61,7 +61,7 @@ build/db:$(START_OBJECTS) $(OBJECTS)
 	@$(CXX) $(CFLAGS) -o $@ $^ -L$(LIBPATH) $(LIBS)
 
 build/tests:$(OBJECTS) $(BATCHING_OBJECTS) $(TESTOBJECTS) $(NON_MAIN_STARTS)
-	@$(CXX) $(CFLAGS) $(INCLUDE) -o $@ $^ $(LIBS) $(TEST_LIBS)
+	@$(CXX) $(CFLAGS) $(INCLUDE) -o $@ $^ -L$(LIBPATH) $(LIBS) $(TEST_LIBS)
 
 $(DEPSDIR)/stamp:
 	@mkdir -p $(DEPSDIR)

--- a/include/batch/arr_container.h
+++ b/include/batch/arr_container.h
@@ -36,8 +36,8 @@ protected:
 public:
   ArrayContainer(std::unique_ptr<BatchActions> actions);
 
-  BatchAction* peek_curr_elt() override;
-  std::unique_ptr<BatchAction> take_curr_elt() override;
+  BatchActionInterface* peek_curr_elt() override;
+  std::unique_ptr<BatchActionInterface> take_curr_elt() override;
   void advance_to_next_elt() override;
   void sort_remaining() override;
   uint32_t get_remaining_count() override;

--- a/include/batch/batch_action.h
+++ b/include/batch/batch_action.h
@@ -1,28 +1,36 @@
 #ifndef BATCH_ACTION_H_
 #define BATCH_ACTION_H_
 
-#include <db.h>
+#include "batch/batch_action_interface.h"
 
-#include <stdint.h>
-#include <unordered_set>
-
-class BatchAction : public translator {
+// BatchAction
+//
+//    Concrete implementation of actions used within our system.
+class BatchAction : public BatchActionInterface {
+  private:
+    RecordKeySet readset;
+    RecordKeySet writeset;
   public:
-    // typedefs
-    typedef uint64_t RecKey;
-    typedef std::unordered_set<RecKey> RecSet;
+    BatchAction(txn* t): BatchActionInterface(t) {};
 
-    BatchAction(txn* t): translator(t) {};
-
-    virtual void add_read_key(RecKey rk) = 0;
-    virtual void add_write_key(RecKey rk) = 0;
+    // override the translator functions
+    virtual void *write_ref(uint64_t key, uint32_t table) override;
+    virtual void *read(uint64_t key, uint32_t table) override;
+ 
+    // override the BatchActionInterface functions
+    virtual void add_read_key(RecordKey rk) override;
+    virtual void add_write_key(RecordKey rk) override;
+   
+    virtual uint64_t get_readset_size() const override;
+    virtual uint64_t get_writeset_size() const override;
+    virtual RecordKeySet* get_readset_handle() override;
+    virtual RecordKeySet* get_writeset_handle() override;
     
-    virtual uint64_t get_readset_size() const = 0;
-    virtual uint64_t get_writeset_size() const = 0;
-    virtual RecSet* get_readset_handle() = 0;
-    virtual RecSet* get_writeset_handle() = 0;
-
-    virtual bool operator<(const BatchAction& ba2) const = 0;
+    // TODO: 
+    //    Do this after we fill in the interface
+    virtual void run() override;
+    virtual bool operator<(const BatchActionInterface& ba2) const override;
+    virtual int rand() override;
 };
 
 #endif //BATCH_ACTION_H_

--- a/include/batch/batch_action_interface.h
+++ b/include/batch/batch_action_interface.h
@@ -1,0 +1,36 @@
+#ifndef BATCH_ACTION_INTERFACE_H_
+#define BATCH_ACTION_INTERFACE_H_
+
+#include "batch/record_key.h"
+#include "db.h"
+
+#include <stdint.h>
+#include <unordered_set>
+
+// BatchActionInterface
+//
+//    The general interface of an action used within our
+//    system. 
+class BatchActionInterface : public translator {
+  public:
+    // typedefs
+    typedef std::unordered_set<RecordKey> RecordKeySet;
+
+    BatchActionInterface(txn* t): translator(t) {};
+
+    virtual void add_read_key(RecordKey rk) = 0;
+    virtual void add_write_key(RecordKey rk) = 0;
+    
+    virtual uint64_t get_readset_size() const = 0;
+    virtual uint64_t get_writeset_size() const = 0;
+    virtual RecordKeySet* get_readset_handle() = 0;
+    virtual RecordKeySet* get_writeset_handle() = 0;
+
+    // TODO: 
+    //    Run must get a handle to the database storage
+    virtual void run() = 0;
+
+    virtual bool operator<(const BatchActionInterface& ba2) const = 0;
+};
+
+#endif // BATCH_ACTION_INTERFACE_H_

--- a/include/batch/container.h
+++ b/include/batch/container.h
@@ -1,7 +1,7 @@
 #ifndef _CONTAINER_H_
 #define _CONTAINER_H_
 
-#include <batch/batch_action.h>
+#include <batch/batch_action_interface.h>
 
 #include <memory>
 #include <vector>
@@ -17,7 +17,7 @@
 // skipping some of them.
 class Container {
 public:
-  typedef std::vector<std::unique_ptr<BatchAction>> BatchActions;
+  typedef std::vector<std::unique_ptr<BatchActionInterface>> BatchActions;
 protected:
   std::unique_ptr<BatchActions> actions_uptr;
 
@@ -33,14 +33,14 @@ public:
    *
    * Returns nullptr if no elements are left.
    */
-  virtual BatchAction* peek_curr_elt() = 0;
+  virtual BatchActionInterface* peek_curr_elt() = 0;
   /*
    * Obtain ownership over the currently minimum element. The element
    * is removed from the container. curr_elt is advanced to the next element.
    *
    * Returns nullptr if no elements are left.
    */
-  virtual std::unique_ptr<BatchAction> take_curr_elt() = 0;
+  virtual std::unique_ptr<BatchActionInterface> take_curr_elt() = 0;
   /*
    * Get the number of elements remaining in the container.
    */

--- a/include/batch/input_queue.h
+++ b/include/batch/input_queue.h
@@ -2,7 +2,7 @@
 #define _GLOBAL_INPUT_QUEUE_H_
 
 #include "batch/MS_queue.h"
-#include "batch/batch_action.h"
+#include "batch/batch_action_interface.h"
 #include "batch/scheduler.h"
 
 #include <vector>
@@ -24,11 +24,11 @@ class Scheduler;
  *    Enqueueing is done by the simulation framework, which ensures that only one thread
  *    enqueues at a time.
  */
-class InputQueue : public MSQueue<std::unique_ptr<BatchAction>> {
+class InputQueue : public MSQueue<std::unique_ptr<BatchActionInterface>> {
   private:
     uint64_t holder;
     std::vector<Scheduler*> schedulers;
-    using MSQueue<std::unique_ptr<BatchAction>>::merge_queue;
+    using MSQueue<std::unique_ptr<BatchActionInterface>>::merge_queue;
   public:
     InputQueue();
     void initialize(std::vector<Scheduler*> schedulers);

--- a/include/batch/lock_stage.h
+++ b/include/batch/lock_stage.h
@@ -2,10 +2,11 @@
 #define _LOCK_STAGE_H_
 
 #include "batch/lock_types.h"
-#include "batch/batch_action.h"
+#include "batch/batch_action_interface.h"
 
 #include <memory>
 #include <stdint.h>
+#include <unordered_set>
 
 // TODO: Override the new/delete operators
 // TODO: implement a public inheritance test class which provides a == operator.
@@ -25,7 +26,7 @@
  */
 class LockStage {
 public:
-  typedef std::unordered_set<std::shared_ptr<BatchAction>> RequestingActions;
+  typedef std::unordered_set<std::shared_ptr<BatchActionInterface>> RequestingActions;
 
 protected:
   // The number of transactions holding on to the lock.
@@ -43,7 +44,7 @@ public:
   //
   // May only be called in a single-threaded scenarios. We do not coalesce adjacent shared stages
   // into single stages.
-  bool add_to_stage(std::shared_ptr<BatchAction> txn, LockType lt);
+  bool add_to_stage(std::shared_ptr<BatchActionInterface> txn, LockType lt);
   // Returns the new value of holders
   uint64_t decrement_holders(); 
   

--- a/include/batch/lock_table.h
+++ b/include/batch/lock_table.h
@@ -1,7 +1,7 @@
 #ifndef _LOCK_TABLE_H_
 #define _LOCK_TABLE_H_
 
-#include "batch/batch_action.h"
+#include "batch/batch_action_interface.h"
 #include "batch/lock_queue.h"
 
 #include <unordered_map>
@@ -28,7 +28,7 @@ class BatchLockTable;
 //    This should only be done after we have seen that this reduced throughput by a lot.
 class LockTable {
 public:
-  typedef std::unordered_map<BatchAction::RecKey, std::shared_ptr<LockQueue>> LockTableType;
+  typedef std::unordered_map<RecordKey, std::shared_ptr<LockQueue>> LockTableType;
 protected:
   LockTableType lock_table;
   std::mutex merge_batch_table_mutex;
@@ -52,12 +52,12 @@ public:
 //    easily merged into the global LockTable.
 class BatchLockTable {
 public:
-  typedef std::unordered_map<BatchAction::RecKey, std::shared_ptr<BatchLockQueue>> LockTableType;
+  typedef std::unordered_map<RecordKey, std::shared_ptr<BatchLockQueue>> LockTableType;
 protected:
   LockTableType lock_table;
 public:
   BatchLockTable();
-  void insert_lock_request(std::shared_ptr<BatchAction> request);
+  void insert_lock_request(std::shared_ptr<BatchActionInterface> request);
   const LockTableType& get_lock_table_data();
 
   friend class LockTable;

--- a/include/batch/packing.h
+++ b/include/batch/packing.h
@@ -2,6 +2,7 @@
 #define PACKING_H_
 
 #include <batch/container.h>
+#include <batch/batch_action_interface.h>
 
 #include <vector>
 #include <unordered_set>
@@ -13,16 +14,15 @@
  **/
 class Packer {
 private:
-  typedef BatchAction::RecKey RecordKey;
-  typedef BatchAction::RecSet RecordSet;
+  typedef BatchActionInterface::RecordKeySet RecordKeySet;
   typedef Container::BatchActions BatchActions;
 
   Packer();
 
   static bool txn_conflicts(
-      BatchAction* t, 
-      RecordSet* ex_locks_in_packing, 
-      RecordSet* sh_locks_in_packing); 
+      BatchActionInterface* t, 
+      RecordKeySet* ex_locks_in_packing, 
+      RecordKeySet* sh_locks_in_packing); 
 
 public:
   static BatchActions get_packing(Container* c);

--- a/include/batch/record_key.h
+++ b/include/batch/record_key.h
@@ -1,0 +1,35 @@
+#ifndef BATCH_RECORD_KEY_H_
+#define BATCH_RECORD_KEY_H_
+
+#include <city.h>
+#include <cstdint>
+#include <functional>
+#include <utility>
+
+// RecordKey
+//
+//    The representation of record key index used to specify a record.
+//    The reason for the existance of this instead of using a bare integer
+//    is the existence of multiple tables.
+class RecordKey {
+  public:
+    static constexpr uint64_t DEFAULT_TABLE_ID = 0;
+  
+    uint64_t key;
+    uint64_t table_id;
+
+    RecordKey(uint64_t key, uint64_t table_id = DEFAULT_TABLE_ID);
+
+    bool operator==(const RecordKey &other) const;
+};
+
+namespace std {
+  template <>
+  struct hash<RecordKey> {
+    size_t operator() (const RecordKey &k) const {
+      return Hash128to64(std::make_pair(k.key, k.table_id)); 
+    }
+  };
+}
+
+#endif // BATCH_RECORD_KEY_H_

--- a/include/batch/scheduler.h
+++ b/include/batch/scheduler.h
@@ -1,7 +1,7 @@
 #ifndef BATCH_SCHEDULER_H_
 #define BATCH_SCHEDULER_H_
 
-#include "batch/batch_action.h"
+#include "batch/batch_action_interface.h"
 #include "batch/lock_table.h"
 #include "batch/MS_queue.h"
 #include "batch/container.h"
@@ -91,7 +91,7 @@ public:
   SchedulerState get_state();
   unsigned int get_max_actions();
 
-  virtual void put_action(std::unique_ptr<BatchAction> act);
+  virtual void put_action(std::unique_ptr<BatchActionInterface> act);
 
   // All of the below are thread safe.
   bool signal_waiting_for_input();

--- a/include/test/test_action.h
+++ b/include/test/test_action.h
@@ -1,7 +1,7 @@
 #ifndef _TEST_ACTION_H_
 #define _TEST_ACTION_H_
 
-#include <batch/batch_action.h>
+#include <batch/batch_action_interface.h>
 #include <test/test_txn.h>
 
 /*
@@ -15,14 +15,15 @@
  *    just a declaration of a static function!
  */
 
-class TestAction : public BatchAction {
+class TestAction : public BatchActionInterface {
 private:
-  RecSet writeSet;
-  RecSet readSet;
+  RecordKeySet writeSet;
+  RecordKeySet readSet;
   uint64_t id;
+  
 public: 
-  TestAction(txn* txn): BatchAction(txn), id(0) {} 
-  TestAction(txn* txn, uint64_t id): BatchAction(txn), id(id) {}
+  TestAction(txn* txn): BatchActionInterface(txn), id(0) {} 
+  TestAction(txn* txn, uint64_t id): BatchActionInterface(txn), id(id) {}
 
   // override the translator functions
   void *write_ref(uint64_t key, uint32_t table) override {
@@ -38,16 +39,17 @@ public:
   int rand() override {return 0;}
 
   // override the BatchAction functions.
-  void add_read_key(RecKey rk) override {readSet.insert(rk);}
-  void add_write_key(RecKey rk) override {writeSet.insert(rk);}
+  void add_read_key(RecordKey rk) override {readSet.insert(rk);}
+  void add_write_key(RecordKey rk) override {writeSet.insert(rk);}
 
   uint64_t get_readset_size() const override {return readSet.size();}
   uint64_t get_writeset_size() const override {return writeSet.size();}
-  RecSet* get_readset_handle() {return &readSet;}
-  RecSet* get_writeset_handle() {return &writeSet;}
+  RecordKeySet* get_readset_handle() {return &readSet;}
+  RecordKeySet* get_writeset_handle() {return &writeSet;}
 
+  void run() override {};
   // inequality calculated based on the overall number of transactions.
-  bool operator<(const BatchAction& ta) const {
+  bool operator<(const BatchActionInterface& ta) const {
     return (get_readset_size() + get_writeset_size() <
       ta.get_readset_size() + ta.get_writeset_size());
   }
@@ -55,8 +57,8 @@ public:
   // own functions
   uint64_t get_id() const {return id;}
   static TestAction* make_test_action_with_test_txn(
-      RecSet writes,
-      RecSet reads,
+      RecordKeySet writes,
+      RecordKeySet reads,
       uint64_t id = 0) {
     TestAction* ta = new TestAction(new TestTxn());
 

--- a/include/test/test_lock_table.h
+++ b/include/test/test_lock_table.h
@@ -1,7 +1,7 @@
 #ifndef TEST_LOCK_TABLE_H_
 #define TEST_LOCK_TABLE_H_
 
-#include "batch/batch_action.h"
+#include "batch/batch_action_interface.h"
 #include "test/test_lock_stage.h"
 
 class TestLockTable : public LockTable {
@@ -11,7 +11,7 @@ class TestLockTable : public LockTable {
       return lock_table;
     }
 
-    bool lock_table_contains_stage(BatchAction::RecKey k, LockStage* ls) {
+    bool lock_table_contains_stage(RecordKey k, LockStage* ls) {
       auto lq = lock_table.find(k);
       if (lq == lock_table.end()) return false;
 

--- a/include/test/test_scheduler.h
+++ b/include/test/test_scheduler.h
@@ -6,9 +6,9 @@
 class TestScheduler : public Scheduler {
 public:
   TestScheduler(SchedulerConfig cf): Scheduler(cf) {};
-  std::vector<std::unique_ptr<BatchAction>> put_actions;
+  std::vector<std::unique_ptr<BatchActionInterface>> put_actions;
   
-  void put_action(std::unique_ptr<BatchAction> act) override {
+  void put_action(std::unique_ptr<BatchActionInterface> act) override {
     put_actions.push_back(std::move(act));
   };
 };

--- a/src/batch/arr_container.cc
+++ b/src/batch/arr_container.cc
@@ -13,20 +13,21 @@ bool ArrayContainer::arr_is_empty() {
     current_min_index < current_barrier_index;
 }
 
-BatchAction* ArrayContainer::peek_curr_elt() {
+BatchActionInterface* ArrayContainer::peek_curr_elt() {
   if (arr_is_empty()) return nullptr;
 
   // return the pointer within unique_ptr of the right elt.
   return ((*this->actions_uptr)[current_min_index].get());
 }
 
-std::unique_ptr<BatchAction> ArrayContainer::take_curr_elt() {
+std::unique_ptr<BatchActionInterface> ArrayContainer::take_curr_elt() {
   if (arr_is_empty()) return nullptr;
 
   // swap the current min with the current barrier index one. That
   // puts the element into the "removed elements". Note that 
   // this does not free memory etc.
-  std::unique_ptr<BatchAction> min = std::move((*this->actions_uptr)[current_min_index]);
+  std::unique_ptr<BatchActionInterface> min = 
+    std::move((*this->actions_uptr)[current_min_index]);
   (*this->actions_uptr)[current_min_index] = 
     std::move((*this->actions_uptr)[current_barrier_index]);
 
@@ -45,8 +46,8 @@ void ArrayContainer::sort_remaining() {
       this->actions_uptr->end(),
       // NOTE: this makes use of an overloaded < operator for Actions!
       [](
-        std::unique_ptr<BatchAction> const& a, 
-        std::unique_ptr<BatchAction> const& b) 
+        std::unique_ptr<BatchActionInterface> const& a, 
+        std::unique_ptr<BatchActionInterface> const& b) 
       {return *a < *b;});
 
   current_min_index = current_barrier_index;

--- a/src/batch/batch_action.cc
+++ b/src/batch/batch_action.cc
@@ -1,0 +1,60 @@
+#include <batch/batch_action.h>
+#include <cassert>
+
+uint64_t BatchAction::get_readset_size() const {
+  return readset.size();
+}
+
+uint64_t BatchAction::get_writeset_size() const {
+  return writeset.size();
+}
+
+void BatchAction::add_write_key(RecordKey rk) {
+  writeset.insert(rk);
+}
+
+void BatchAction::add_read_key(RecordKey rk) {
+  readset.insert(rk);
+}
+
+void* BatchAction::write_ref(uint64_t key, uint32_t table) {
+  RecordKey rk(key, table);
+  auto it = writeset.find(rk);
+  assert(it != writeset.end());//record must be part of this action
+  // TODO:
+  //    Do we need this anywhere?
+  //return it->record;
+  return nullptr;
+}
+
+void* BatchAction::read(uint64_t key, uint32_t table) {
+  RecordKey rk(key, table);
+  auto it = readset.find(rk);
+  assert(it != readset.end());
+  // TODO:
+  //    Do we need this anywhere?
+  // return it->record;
+  return nullptr;
+};
+
+BatchActionInterface::RecordKeySet* BatchAction::get_readset_handle() {
+  return &readset;
+}
+
+BatchActionInterface::RecordKeySet* BatchAction::get_writeset_handle() {
+  return &writeset;
+}
+
+//currently sort by total number of records in action
+bool BatchAction::operator<(const BatchActionInterface& ba2) const {
+  return (get_readset_size() + get_writeset_size() < 
+          ba2.get_readset_size() + ba2.get_writeset_size());
+}
+
+int BatchAction::rand() {
+  return 0;
+}
+
+void BatchAction::run() {
+  // TODO.
+}

--- a/src/batch/input_queue.cc
+++ b/src/batch/input_queue.cc
@@ -34,7 +34,7 @@ void InputQueue::obtain_batch(Scheduler* s) {
     while (s->get_state() != SchedulerState::input);
   } 
 
-  std::unique_ptr<BatchAction>* act;
+  std::unique_ptr<BatchActionInterface>* act;
   for (unsigned int actionsTaken = 0; 
       actionsTaken < s->get_max_actions(); 
       actionsTaken ++) {

--- a/src/batch/lock_stage.cc
+++ b/src/batch/lock_stage.cc
@@ -18,7 +18,7 @@ LockStage::LockStage(
     assert(!(lt == LockType::exclusive && requesters.size() > 1));
   };
 
-bool LockStage::add_to_stage(std::shared_ptr<BatchAction> txn, LockType lt) {
+bool LockStage::add_to_stage(std::shared_ptr<BatchActionInterface> txn, LockType lt) {
   // can only add to a stage when both the request and the stage are shared
   // or when the stage is empty.
   if ((lt == LockType::exclusive && requesters.size() > 0) ||

--- a/src/batch/lock_table.cc
+++ b/src/batch/lock_table.cc
@@ -27,8 +27,9 @@ void LockTable::merge_batch_table(BatchLockTable& blt) {
 
 BatchLockTable::BatchLockTable() {}
 
-void BatchLockTable::insert_lock_request(std::shared_ptr<BatchAction> req) {
-  auto add_request = [this, &req](BatchAction::RecSet* set, LockType typ) {
+void BatchLockTable::insert_lock_request(std::shared_ptr<BatchActionInterface> req) {
+  auto add_request = [this, &req](
+      BatchActionInterface::RecordKeySet* set, LockType typ) {
     std::shared_ptr<BatchLockQueue> blq;
     for (auto& i : *set) {
       blq = lock_table.emplace(i, std::make_shared<BatchLockQueue>()).first->second;

--- a/src/batch/packing.cc
+++ b/src/batch/packing.cc
@@ -1,20 +1,20 @@
 #include "batch/packing.h"
-#include "batch/batch_action.h"
+#include "batch/batch_action_interface.h"
 
 bool Packer::txn_conflicts(
-    BatchAction* t,
-    RecordSet* ex_locks_in_packing, 
-    RecordSet* sh_locks_in_packing) {
+    BatchActionInterface* t,
+    RecordKeySet* ex_locks_in_packing, 
+    RecordKeySet* sh_locks_in_packing) {
   auto t_ex = t->get_writeset_handle();
   auto t_sh = t->get_readset_handle();
 
   // We will be iterating over sets. Always pick the smaller one to
   // iterate over.
-  RecordSet* smaller;
-  RecordSet* larger;
+  RecordKeySet* smaller;
+  RecordKeySet* larger;
 
   auto conflictExists = 
-       [&smaller, &larger](RecordSet* rs1, RecordSet* rs2){
+       [&smaller, &larger](RecordKeySet* rs1, RecordKeySet* rs2){
 
     // pick the smaller set to iterate over.
     if (rs1->size() > rs2->size()) {
@@ -47,14 +47,14 @@ bool Packer::txn_conflicts(
 }
 
 Packer::BatchActions Packer::get_packing(Container* c) {
-  RecordSet held_ex_locks;
-  RecordSet held_sh_locks; 
+  RecordKeySet held_ex_locks;
+  RecordKeySet held_sh_locks; 
 
   BatchActions actions_in_packing;
-  BatchAction* next_action;
-  std::unique_ptr<BatchAction> action;
+  BatchActionInterface* next_action;
+  std::unique_ptr<BatchActionInterface> action;
 
-  auto merge_sets = [](RecordSet* mergeTo, RecordSet* mergeFrom) {
+  auto merge_sets = [](RecordKeySet* mergeTo, RecordKeySet* mergeFrom) {
     for (auto it = mergeFrom->begin(); it != mergeFrom->end(); it++) {
       mergeTo->insert(*it);
     }

--- a/src/batch/record_key.cc
+++ b/src/batch/record_key.cc
@@ -1,0 +1,9 @@
+#include "batch/record_key.h"
+
+constexpr uint64_t RecordKey::DEFAULT_TABLE_ID;
+
+RecordKey::RecordKey(uint64_t key, uint64_t table_id): key(key), table_id(table_id) {};
+
+bool RecordKey::operator==(const RecordKey& other) const {
+  return (key == other.key && table_id == other.table_id);
+}

--- a/src/batch/scheduler.cc
+++ b/src/batch/scheduler.cc
@@ -12,7 +12,7 @@ Scheduler::Scheduler(SchedulerConfig sc):
 {
   // allocate memory up front.
   batch_actions = 
-    std::make_unique<std::vector<std::unique_ptr<BatchAction>>>(
+    std::make_unique<std::vector<std::unique_ptr<BatchActionInterface>>>(
         sc.batch_size_act);
 }
 
@@ -46,17 +46,17 @@ void Scheduler::make_batch_schedule() {
   // construct array container from the batch
   ArrayContainer ac(std::move(batch_actions));
   batch_actions = 
-    std::make_unique<std::vector<std::unique_ptr<BatchAction>>>(
+    std::make_unique<std::vector<std::unique_ptr<BatchActionInterface>>>(
         conf.batch_size_act);
 
-  std::vector<std::unique_ptr<BatchAction>> packing;
+  std::vector<std::unique_ptr<BatchActionInterface>> packing;
   while (ac.get_remaining_count() != 0) {
     // get packing
     packing = Packer::get_packing(&ac);
     ac.sort_remaining();
     // translate a packing into lock request
-    for (std::unique_ptr<BatchAction>& act : packing) {
-      lt.insert_lock_request(std::shared_ptr<BatchAction>(std::move(act)));
+    for (std::unique_ptr<BatchActionInterface>& act : packing) {
+      lt.insert_lock_request(std::shared_ptr<BatchActionInterface>(std::move(act)));
     }
   }
 }
@@ -65,7 +65,7 @@ unsigned int Scheduler::get_max_actions() {
   return conf.batch_size_act;
 };
 
-void Scheduler::put_action(std::unique_ptr<BatchAction> act) {
+void Scheduler::put_action(std::unique_ptr<BatchActionInterface> act) {
   batch_actions->push_back(std::move(act)); 
 };
 

--- a/test/action_test.cc
+++ b/test/action_test.cc
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+#include <batch/batch_action.h>
+#include <test/test_txn.h>
+
+class BatchActionTest : public ::testing::Test {
+protected:
+  BatchAction* create_action_with_records(
+      BatchAction::RecordKeySet readset, 
+      BatchAction::RecordKeySet writeset) {
+    BatchAction* action = new BatchAction(new TestTxn());
+    for (auto it = readset.begin(); it != readset.end(); ++it) {
+      action->add_read_key(*it);
+    }
+
+    for (auto it = writeset.begin(); it != writeset.end(); ++it) {
+      action->add_write_key(*it);
+    }
+    return action;
+  };
+}; 
+
+TEST(RecordKeyTest, CreateAndVerify) {
+  RecordKey a(1, 2);
+  ASSERT_EQ(a.key, 1);
+  ASSERT_EQ(a.table_id, 2);
+
+  RecordKey b(10);
+  ASSERT_EQ(b.key, 10);
+  ASSERT_EQ(b.table_id, RecordKey::DEFAULT_TABLE_ID);
+}
+
+TEST(RecordKeyTest, EqualityTest) {
+  RecordKey a(1, 1);
+  RecordKey b(1, 1);
+  ASSERT_EQ(a, b);
+
+  RecordKey c(1);
+  RecordKey d(1);
+  ASSERT_EQ(c, d);
+
+  ASSERT_FALSE(a == c);
+}
+
+// add record keys and show readsets/writesets grow
+TEST_F(BatchActionTest, AddingToActions) {
+  BatchAction* a = create_action_with_records({{2,1}, {2,2}},{{10,20}});
+
+  ASSERT_EQ(a->get_readset_size(), 2);
+  ASSERT_EQ(a->get_writeset_size(), 1);
+
+}
+
+// create actions with different readset/writeset sizes and compare
+TEST_F(BatchActionTest, ComparingActions) {
+  BatchAction* a = create_action_with_records({1,2,3},{4,5,6});//6
+  BatchAction* b = create_action_with_records({1,2,3,4,5}, {});//5
+  BatchAction* c = create_action_with_records({1}, {2,3,4,5}); //5
+
+
+  ASSERT_TRUE(*b < *a); //5<6
+  ASSERT_TRUE(*c < *a);
+  ASSERT_FALSE(*a < *b);//6<5
+  ASSERT_FALSE(*a < *c);
+  
+  ASSERT_FALSE(*a < *a);//6<6
+  ASSERT_FALSE(*b < *c);
+  ASSERT_FALSE(*c < *b);
+}
+
+// TODO:
+//    When we figure out if we need the read/write refs, this will come back
+//    or get deleted.
+//// create record keys with specific pointers and fetch them
+//TEST_F(BatchActionTest, CheckingRefs) {
+//  BatchRecord x = 10;
+//  BatchRecord y = 11;
+//
+//  RecordKey r1(1, 0); 
+//  RecordKey r2(1, 1); 
+//  r1.record = &x;
+//  r2.record = &y;
+//
+//  BatchAction* action = create_action_with_records({r1}, {r2}); 
+//  
+//  ASSERT_EQ(*((BatchRecord*) action->read(1, 0)), 10);
+//  ASSERT_EQ(*((BatchRecord*) action->write_ref(1, 1)), 11);
+//}

--- a/test/packing_test.cc
+++ b/test/packing_test.cc
@@ -8,14 +8,15 @@
 
 class PackingTest : public testing::Test {
 private:
-  std::vector<TestAction::RecSet> readSets;
-  std::vector<TestAction::RecSet> writeSets;
+  typedef BatchActionInterface::RecordKeySet RecordKeySet;
+  std::vector<RecordKeySet> readSets;
+  std::vector<RecordKeySet> writeSets;
 protected:
   std::unique_ptr<ArrayContainer> testContainer;
 
   void addActionFromSets(
-      TestAction::RecSet writeSet,
-      TestAction::RecSet readSet) {
+      RecordKeySet writeSet,
+      RecordKeySet readSet) {
     readSets.push_back(readSet);
     writeSets.push_back(writeSet);    
   }


### PR DESCRIPTION
Implementation for the interface of BatchAction.

Main addition here is the RecordKey, which has an (int) key, an (int) table_id,  and a pointer to the actual record. RecordKeys are equal if their key and table_id match, and have a hash implementation so they can be used as keys in maps or added to sets. 

The last few days have taught me that I'm terrible at c++, so criticism is welcome. 